### PR TITLE
Edge Case scenario with Specific NPC's (Titan's Heart and Golem souls…

### DIFF
--- a/MOAction/MOAction.cs
+++ b/MOAction/MOAction.cs
@@ -306,7 +306,7 @@ namespace MOAction
                 PluginLog.Debug("The subkind was: " + b.BattleNpcKind + " with name: " + b.Name);
                 PluginLog.Debug("DataId " + b.DataId);
                 //Soon The BattleNpcKind Enum will get a new enum for 1: Weak spot/Battle npc part
-                if (!(b.BattleNpcKind == BattleNpcSubKind.Enemy || ((int)b.BattleNpcKind) == 1))
+                if (!(b.BattleNpcKind == BattleNpcSubKind.Enemy || b.BattleNpcKind == BattleNpcSubKind.BattleNpcPart);
                 {
                     return action.CanTargetFriendly ||
                         action.CanTargetParty ||
@@ -325,7 +325,7 @@ namespace MOAction
                         UnorthodoxFriendly.Contains((uint)action.RowId);
             }
             
-            PluginLog.Debug("Objectkind was: " + target.ObjectKind + "with name: " + target.Name);
+            PluginLog.Debug("Objectkind was: " + target.ObjectKind + " with name: " + target.Name);
             return action.CanTargetHostile ||
                 action.TargetArea ||
                 UnorthodoxHostile.Contains((uint)action.RowId);

--- a/MOAction/MOAction.cs
+++ b/MOAction/MOAction.cs
@@ -298,16 +298,15 @@ namespace MOAction
                     action.CanTargetParty ||
                     action.CanTargetSelf ||
                     action.TargetArea ||
-                    action.RowId == 17055 || action.RowId == 7443;
+                    UnorthodoxFriendly.Contains((uint)action.RowId);
+
             if (target.ObjectKind == ObjectKind.BattleNpc)
             {
                 BattleNpc b = (BattleNpc)target;
                 PluginLog.Debug("The subkind was: " + b.BattleNpcKind + " with name: " + b.Name);
                 PluginLog.Debug("DataId " + b.DataId);
-                if (
-                     !(b.BattleNpcKind == BattleNpcSubKind.Enemy || ((int)b.BattleNpcKind) == 1) //Soon The BattleNpcKind Enum will get a new enum for 1: Weak spot/Battle npc part
-                        || HealableBattleNpcs.Contains((uint)b.DataId) //started keeping a list of uint's of NPC's that are battle npc enemies, but can be healed
-                        )
+                //Soon The BattleNpcKind Enum will get a new enum for 1: Weak spot/Battle npc part
+                if (!(b.BattleNpcKind == BattleNpcSubKind.Enemy || ((int)b.BattleNpcKind) == 1))
                 {
                     return action.CanTargetFriendly ||
                         action.CanTargetParty ||
@@ -316,6 +315,16 @@ namespace MOAction
                         UnorthodoxFriendly.Contains((uint)action.RowId);
                 }
             }
+             //Custom case for specific npcs that are healable non-party frame existing
+            if(HealableBattleNpcs.Contains(target.DataId)){
+                PluginLog.Debug("Custom NPC case for a healable NPC, ID: " + target.DataId);
+                  return action.CanTargetFriendly ||
+                        action.CanTargetParty ||
+                        action.CanTargetSelf ||
+                        action.TargetArea ||
+                        UnorthodoxFriendly.Contains((uint)action.RowId);
+            }
+            
             PluginLog.Debug("Objectkind was: " + target.ObjectKind + "with name: " + target.Name);
             return action.CanTargetHostile ||
                 action.TargetArea ||

--- a/MOAction/MOAction.cs
+++ b/MOAction/MOAction.cs
@@ -109,6 +109,7 @@ namespace MOAction
             UnorthodoxFriendly.Add(7443);
             //These are NPC classified as BattleNpc and Enemy, where healing actions work on
             HealableBattleNpcs.Add(3054); //Paiyo Reiyo - Tam Tara Deepcroft (hard)
+            HealableBattleNpcs.Add(13117); //Haurchefant - Dragon song Reprise Ultimate
         }
 
         public void SetConfig(MOActionConfiguration config)

--- a/MOAction/MOAction.cs
+++ b/MOAction/MOAction.cs
@@ -296,11 +296,16 @@ namespace MOAction
             if (target.ObjectKind == ObjectKind.BattleNpc)
             {
                 BattleNpc b = (BattleNpc)target;
-                if (b.BattleNpcKind != BattleNpcSubKind.Enemy) return action.CanTargetFriendly || 
+                //Titan's heart and Sunken temple of Qarn Golem soulstone (npcs without a hitbox) returned 1 on battleNpcKind, 
+                //this specific edge case should default to the hostile action in the actionstack instead of CanTargetFriendly
+                if (b.BattleNpcKind != BattleNpcSubKind.Enemy && ((int)b.BattleNpcKind) != 1) {
+                    PluginLog.Debug("The subkind was: " + b.BattleNpcKind);
+                    return action.CanTargetFriendly || 
                         action.CanTargetParty ||
                         action.CanTargetSelf ||
                         action.TargetArea ||
                         UnorthodoxFriendly.Contains((uint)action.RowId);
+                }
             }
             return action.CanTargetHostile || 
                 action.TargetArea ||

--- a/MOAction/MOAction.cs
+++ b/MOAction/MOAction.cs
@@ -108,7 +108,7 @@ namespace MOAction
             UnorthodoxFriendly.Add(17055);
             UnorthodoxFriendly.Add(7443);
             //These are NPC classified as BattleNpc and Enemy, where healing actions work on
-            HealableBattleNpcs.Add(1073745861); //Paiyo Reiyo - Tam Tara Deepcroft (hard)
+            HealableBattleNpcs.Add(3054); //Paiyo Reiyo - Tam Tara Deepcroft (hard)
         }
 
         public void SetConfig(MOActionConfiguration config)
@@ -302,10 +302,10 @@ namespace MOAction
             {
                 BattleNpc b = (BattleNpc)target;
                 PluginLog.Debug("The subkind was: " + b.BattleNpcKind + " with name: " + b.Name);
-                PluginLog.Debug("" + b.ObjectId);
+                PluginLog.Debug("DataId " + b.DataId);
                 if (
                      !(b.BattleNpcKind == BattleNpcSubKind.Enemy || ((int)b.BattleNpcKind) == 1) //Soon The BattleNpcKind Enum will get a new enum for 1: Weak spot/Battle npc part
-                        || HealableBattleNpcs.Contains((uint)b.ObjectId) //started keeping a list of uint's of NPC's that are battle npc enemies, but can be healed
+                        || HealableBattleNpcs.Contains((uint)b.DataId) //started keeping a list of uint's of NPC's that are battle npc enemies, but can be healed
                         )
                 {
                     return action.CanTargetFriendly ||

--- a/MOAction/MOAction.cs
+++ b/MOAction/MOAction.cs
@@ -296,10 +296,11 @@ namespace MOAction
             if (target.ObjectKind == ObjectKind.BattleNpc)
             {
                 BattleNpc b = (BattleNpc)target;
+                PluginLog.Debug("The subkind was: " + b.BattleNpcKind + "with name: " + b.Name);
                 //Titan's heart and Sunken temple of Qarn Golem soulstone (npcs without a hitbox) returned 1 on battleNpcKind, 
                 //this specific edge case should default to the hostile action in the actionstack instead of CanTargetFriendly
+                //some more testing later in solm al and baram's mettle, battleNpcKind 1 means weak point/Battle npc part
                 if (b.BattleNpcKind != BattleNpcSubKind.Enemy && ((int)b.BattleNpcKind) != 1) {
-                    PluginLog.Debug("The subkind was: " + b.BattleNpcKind);
                     return action.CanTargetFriendly || 
                         action.CanTargetParty ||
                         action.CanTargetSelf ||
@@ -307,6 +308,7 @@ namespace MOAction
                         UnorthodoxFriendly.Contains((uint)action.RowId);
                 }
             }
+            PluginLog.Debug("Objectkind was: "+ target.ObjectKind + "with name: "+ target.Name);
             return action.CanTargetHostile || 
                 action.TargetArea ||
                 UnorthodoxHostile.Contains((uint)action.RowId);


### PR DESCRIPTION
So I found out that when you run b.BattleNpcKind on specifically Titan's Heart (Titan) OR The Golem soul stone (from Sunken temple of Qarn) battleNpcKind returns an enum value of "1".  in this specific edge-case the correct action would be to default to the CanTargetHostile.

I'm going to use this version for a while and return with more info if this has any breaking changes anywhere that's not the intended behaviour that I intended to change with titan and qarn and hostile npcs like them.