### PR TITLE
BattleNpcSubKind.BattleNpcPart was added to Dalamud: this enemy type …

### DIFF
--- a/MOAction/MOAction.cs
+++ b/MOAction/MOAction.cs
@@ -296,13 +296,15 @@ namespace MOAction
             if (target.ObjectKind == ObjectKind.BattleNpc)
             {
                 BattleNpc b = (BattleNpc)target;
-                if (b.BattleNpcKind != BattleNpcSubKind.Enemy) return action.CanTargetFriendly || 
+                if (!(b.BattleNpcKind == BattleNpcSubKind.Enemy || b.BattleNpcKind == BattleNpcSubKind.BattleNpcPart)){
+                    return action.CanTargetFriendly ||
                         action.CanTargetParty ||
                         action.CanTargetSelf ||
                         action.TargetArea ||
                         UnorthodoxFriendly.Contains((uint)action.RowId);
+                }
             }
-            return action.CanTargetHostile || 
+            return action.CanTargetHostile ||
                 action.TargetArea ||
                 UnorthodoxHostile.Contains((uint)action.RowId);
         }


### PR DESCRIPTION
BattleNpcSubKind.BattleNpcPart was added to Dalamud: this enemy type are hostile enemies that can be targeted but do not have their own hitbox. eg: a Dragon's left/right wing in somh al, the Golem's core in sunken temple of Qarn, titan's heart,...