### PR TITLE
Feature/healable battle npc enemies

### DIFF
--- a/MOAction/MOAction.cs
+++ b/MOAction/MOAction.cs
@@ -4,7 +4,6 @@ using System.Linq;
 using System.Runtime.InteropServices;
 using Dalamud.Game;
 using Dalamud.Game.ClientState.Objects;
-using Dalamud.Game.ClientState.Objects.Enums;
 using Dalamud.Game.ClientState.Objects.Types;
 using Dalamud.Hooking;
 using Dalamud.Game.ClientState.Keys;
@@ -14,8 +13,6 @@ using FFXIVClientStructs.FFXIV.Client.Game;
 using static MOAction.MOActionAddressResolver;
 using Dalamud;
 using Dalamud.Plugin.Services;
-using Lumina.Excel;
-
 
 namespace MOAction
 {


### PR DESCRIPTION
Some specific NPCS like Paiyo Reiyo from Tam-Tara Deepcroft (HARD) and Haurchefant from DSR (Ultimate) and many of the Healer Job quests are classified as BattleNPCSubKind.Enemy. yet they cannot be targeted by hostile spells, only friendly spells.

now I'm going to dig and spit through Structs to see if there's any way to differentiate those NPCs from your garden variety of hostile npcs.

for now, this is a temporary fix to have a custom behaviour depending on NPC ID. This is however way too much effort to collect a full list of NPC ids for this.

Leaving this as a draft to note how my personal branch differs from MASTER and to note an open draft/TODO for this odd behaviour.

With love!