### PR TITLE
Major bug: action stacks with base action being a role action are bled between all the jobs who can use that role actions

### DIFF
--- a/MOAction/MOAction.cs
+++ b/MOAction/MOAction.cs
@@ -224,7 +224,11 @@ namespace MOAction
             uint adjusted = AM->GetAdjustedActionId(ActionID);
 
             if (action == null) return (null, null);
-            var applicableActions = Stacks.Where(entry => entry.BaseAction.RowId == action.RowId || entry.BaseAction.RowId == adjusted || AM->GetAdjustedActionId(entry.BaseAction.RowId) == adjusted);
+
+            var applicableActions = Stacks.Where(entry => (entry.BaseAction.RowId == action.RowId || 
+                                                          entry.BaseAction.RowId == adjusted || 
+                                                          AM->GetAdjustedActionId(entry.BaseAction.RowId) == adjusted)
+                                                          && clientState.LocalPlayer.ClassJob.Id == UInt32.Parse(entry.Job));
             
             MoActionStack stackToUse = null;
             foreach (var entry in applicableActions)

--- a/MOAction/MOActionPlugin.cs
+++ b/MOAction/MOActionPlugin.cs
@@ -129,7 +129,8 @@ namespace MOAction
                                     keystate, 
                                     gamegui,
                                     hookprovider, 
-                                    pluginLog);
+                                    pluginLog,
+                                    Jobs.ToDictionary(item => item.RowId));
 
             foreach (var jobname in JobAbbreviations)
             {


### PR DESCRIPTION
Action stacks set with base action being a role action are bleeding between multiple jobs.

EG: if you set up a stack with rescue, Swiftcast as its base action for WHM, this stack will also show up as applicable stacks for AST, SCH and SGE and cause erratic behavior.

the following fix does a check on the fetching of the applicable actions from Stacks by making sure to only grab stacks for your current role.

this however makes it so non-evolved jobs do not share stacks with their evolved kin anymore. working on an extra fix for that

edit: I found this out because I forgot to set up a stack on rescue for SCH, and I just now noticed I forgot to set that stack up and yet I still had the functionality as if I had set it up.