### PR TITLE
6.58 Update

### DIFF
--- a/MOAction/MOAction.csproj
+++ b/MOAction/MOAction.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net7.0-windows</TargetFramework>
+    <TargetFramework>net8.0-windows</TargetFramework>
     <AssemblyTitle>MOActionPlugin</AssemblyTitle>
     <Product>MOActionPlugin</Product>
     <Description>This plugin allows for actions to be used on mouseover targets without a macro.</Description>

--- a/MOAction/MOActionAddressResolver.cs
+++ b/MOAction/MOActionAddressResolver.cs
@@ -9,18 +9,12 @@ namespace MOAction
         public IntPtr SetUiMouseoverEntityId { get; private set; }
         public IntPtr GtQueuePatch { get; private set; }
 
-
-        public IntPtr PronounModule;
-        public IntPtr GetGroupTimer;
-
         public byte[] preGtQueuePatchData {get; set;}
 
         public MOActionAddressResolver(ISigScanner sig)
         {
             SetUiMouseoverEntityId = sig.ScanText("48 89 91 ?? ?? ?? ?? C3 CC CC CC CC CC CC CC CC 48 89 5C 24 ?? 55 56 57 48 81 EC ?? ?? ?? ?? 48 8B 05 ?? ?? ?? ?? 48 33 C4 48 89 84 24 ?? ?? ?? ?? 48 8D B1 ?? ?? ?? ?? 44 89 44 24 ?? 48 8B EA 48 8B D9 48 8B CE 48 8D 15 ?? ?? ?? ?? 41 B9 ?? ?? ?? ??");
-
             GtQueuePatch = sig.ScanModule("75 49 44 8B C3 41 8B D6");
-            PronounModule = sig.GetStaticAddressFromSig("48 8B 0D ?? ?? ?? ?? 48 8D 05 ?? ?? ?? ?? 48 89 05 ?? ?? ?? ?? 48 85 C9 74 0C", 0);
         }
 
         [StructLayout(LayoutKind.Explicit, Size = 0x14)]

--- a/MOAction/MOActionPlugin.cs
+++ b/MOAction/MOActionPlugin.cs
@@ -129,7 +129,8 @@ namespace MOAction
                                     keystate, 
                                     gamegui,
                                     hookprovider, 
-                                    pluginLog);
+                                    pluginLog,
+                                    Jobs.ToDictionary(item => item.RowId));
 
             foreach (var jobname in JobAbbreviations)
             {

--- a/MOAction/packages.lock.json
+++ b/MOAction/packages.lock.json
@@ -1,7 +1,7 @@
 {
   "version": 1,
   "dependencies": {
-    "net7.0-windows7.0": {
+    "net8.0-windows7.0": {
       "DalamudPackager": {
         "type": "Direct",
         "requested": "[2.1.12, )",


### PR DESCRIPTION
- re-write the CanUseAction method using the Dalamud exposed ActionManager to simplify business logic, removing the need for some specific Sigs, only leaving ground target queue patch
- Fixed the **long-standing quest instance bug**
- introduced feature: Level sync Actions, skipping over stacks if your player's level is not high enough
- Fixed a bug with role actions and shared actions (like scholar/summoner res) bleeding between jobs an action stack on "Swiftcast" setup on white mage and Astrologian would conflict.