### PR TITLE
Update/7.0

### DIFF
--- a/MOAction/MOAction.cs
+++ b/MOAction/MOAction.cs
@@ -19,7 +19,7 @@ namespace MOAction
     public class MOAction
     {
         private readonly Dictionary<uint, Lumina.Excel.GeneratedSheets.ClassJob> JobDictionary;
-        public delegate bool OnRequestActionDetour(long param_1, byte param_2, ulong param_3, long param_4,
+        public delegate bool OnRequestActionDetour(long param_1, byte param_2, ulong param_3, ulong param_4,
                        uint param_5, uint param_6, uint param_7, long param_8);
 
         [UnmanagedFunctionPointer(CallingConvention.ThisCall, CharSet = CharSet.Ansi)]
@@ -156,7 +156,7 @@ namespace MOAction
         }
 
 
-        private unsafe bool HandleRequestAction(long param_1, byte actionType, ulong actionID, long target_ptr,
+        private unsafe bool HandleRequestAction(long param_1, byte actionType, ulong actionID, ulong target_ptr,
                        uint param_5, uint param_6, uint param_7, long param_8)
         {
             // Only care about "real" actions. Not doing anything dodgy
@@ -173,7 +173,7 @@ namespace MOAction
                 return requestActionHook.Original(param_1, actionType, actionID, target_ptr, param_5, param_6, param_7, param_8);
             }
 
-            long objectId = target == null ? 0xE0000000 : target.ObjectId;
+            ulong objectId = target == null ? 0xE0000000 : target.GameObjectId;
             pluginLog.Verbose("Execution Action {action} with ActionID {actionid} on object with ObjectId {objectid}", action.Name, action.RowId, objectId);
 
             bool ret = requestActionHook.Original(param_1, actionType, action.RowId, objectId, param_5, param_6, param_7, param_8);
@@ -181,13 +181,13 @@ namespace MOAction
             // Enqueue GT action
             if (action.TargetArea)
             {
-                *(long*)((IntPtr)actionManager + 0x98) = objectId;
+                *(ulong*)((IntPtr)actionManager + 0x98) = objectId;
                 *(byte*)((IntPtr)actionManager + 0xB8) = 1;
             }
             return ret;
         }
 
-        private unsafe (Lumina.Excel.GeneratedSheets.Action action, GameObject target) GetActionTarget(uint ActionID, uint ActionType)
+        private unsafe (Lumina.Excel.GeneratedSheets.Action action, IGameObject target) GetActionTarget(uint ActionID, uint ActionType)
         {
             var action = RawActions.GetRow(ActionID);
 
@@ -238,7 +238,7 @@ namespace MOAction
             return (null, null);
         }
 
-        private unsafe (bool, GameObject Target) CanUseAction(StackEntry targ, uint actionType)
+        private unsafe (bool, IGameObject Target) CanUseAction(StackEntry targ, uint actionType)
         {
             if (targ.Target == null || targ.Action == null) return (false, null);
 
@@ -302,24 +302,24 @@ namespace MOAction
             return (gameCanUseActionResponse, target);
         }
 
-        public unsafe GameObject GetGuiMoPtr()
+        public unsafe IGameObject GetGuiMoPtr()
         {
             return objectTable.CreateObjectReference((IntPtr)pronounModule -> UiMouseOverTarget);
         }
-        public GameObject GetFocusPtr()
+        public IGameObject GetFocusPtr()
         {
             return targetManager.FocusTarget;
         }
-        public GameObject GetRegTargPtr()
+        public IGameObject GetRegTargPtr()
         {
             return targetManager.Target;
         }
-        public GameObject getFieldMo()
+        public IGameObject getFieldMo()
         {
             return targetManager.MouseOverTarget;
         }
 
-        public unsafe GameObject GetActorFromPlaceholder(string placeholder)
+        public unsafe IGameObject GetActorFromPlaceholder(string placeholder)
         {
             return objectTable.CreateObjectReference((IntPtr)pronounModule->ResolvePlaceholder(placeholder, 1, 0));
         }

--- a/MOAction/MOAction.csproj
+++ b/MOAction/MOAction.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net7.0-windows</TargetFramework>
+    <TargetFramework>net8.0-windows</TargetFramework>
     <AssemblyTitle>MOActionPlugin</AssemblyTitle>
     <Product>MOActionPlugin</Product>
     <Description>This plugin allows for actions to be used on mouseover targets without a macro.</Description>

--- a/MOAction/MOAction.csproj
+++ b/MOAction/MOAction.csproj
@@ -1,4 +1,5 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
+
   <PropertyGroup>
     <TargetFramework>net8.0-windows</TargetFramework>
     <AssemblyTitle>MOActionPlugin</AssemblyTitle>
@@ -11,6 +12,8 @@
     <OutputPath>bin\$(Configuration)\</OutputPath>
     <AppDesignerFolder>Properties.bak</AppDesignerFolder>
   </PropertyGroup>
+
+
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugType>full</DebugType>
   </PropertyGroup>
@@ -27,7 +30,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="DalamudPackager" Version="2.1.12" />
+    <PackageReference Include="DalamudPackager" Version="2.1.13" />
     <Reference Include="FFXIVClientStructs">
       <HintPath>$(DalamudLibPath)FFXIVClientStructs.dll</HintPath>
       <Private>false</Private>
@@ -55,6 +58,10 @@
     <Reference Include="Lumina.Excel">
       <HintPath>$(DalamudLibPath)Lumina.Excel.dll</HintPath>
       <Private>false</Private>
+    </Reference>
+    <Reference Include="InteropGenerator.Runtime">
+    <HintPath>$(DalamudLibPath)InteropGenerator.Runtime.dll</HintPath>
+    <Private>false</Private>
     </Reference>
   </ItemGroup>
 </Project>

--- a/MOAction/MOActionAddressResolver.cs
+++ b/MOAction/MOActionAddressResolver.cs
@@ -9,18 +9,12 @@ namespace MOAction
         public IntPtr SetUiMouseoverEntityId { get; private set; }
         public IntPtr GtQueuePatch { get; private set; }
 
-
-        public IntPtr PronounModule;
-        public IntPtr GetGroupTimer;
-
         public byte[] preGtQueuePatchData {get; set;}
 
         public MOActionAddressResolver(ISigScanner sig)
         {
             SetUiMouseoverEntityId = sig.ScanText("48 89 91 ?? ?? ?? ?? C3 CC CC CC CC CC CC CC CC 48 89 5C 24 ?? 55 56 57 48 81 EC ?? ?? ?? ?? 48 8B 05 ?? ?? ?? ?? 48 33 C4 48 89 84 24 ?? ?? ?? ?? 48 8D B1 ?? ?? ?? ?? 44 89 44 24 ?? 48 8B EA 48 8B D9 48 8B CE 48 8D 15 ?? ?? ?? ?? 41 B9 ?? ?? ?? ??");
-
             GtQueuePatch = sig.ScanModule("75 49 44 8B C3 41 8B D6");
-            PronounModule = sig.GetStaticAddressFromSig("48 8B 0D ?? ?? ?? ?? 48 8D 05 ?? ?? ?? ?? 48 89 05 ?? ?? ?? ?? 48 85 C9 74 0C", 0);
         }
 
         [StructLayout(LayoutKind.Explicit, Size = 0x14)]

--- a/MOAction/MOActionAddressResolver.cs
+++ b/MOAction/MOActionAddressResolver.cs
@@ -4,15 +4,22 @@ using System.Runtime.InteropServices;
 
 namespace MOAction
 {
+
     public class MOActionAddressResolver
     {
         public IntPtr GtQueuePatch { get; private set; }
 
         public byte[] preGtQueuePatchData {get; set;}
 
-        public MOActionAddressResolver(ISigScanner sig)
+        public MOActionAddressResolver(ISigScanner sig, bool enableGroundTargetQueuePatch)
         {
+            
+            if(enableGroundTargetQueuePatch){
             GtQueuePatch = sig.ScanModule("75 49 44 8B C3 41 8B D6");
+            }
+            else{
+                GtQueuePatch = 0;
+            }
         }
 
         [StructLayout(LayoutKind.Explicit, Size = 0x14)]

--- a/MOAction/MOActionAddressResolver.cs
+++ b/MOAction/MOActionAddressResolver.cs
@@ -6,14 +6,12 @@ namespace MOAction
 {
     public class MOActionAddressResolver
     {
-        public IntPtr SetUiMouseoverEntityId { get; private set; }
         public IntPtr GtQueuePatch { get; private set; }
 
         public byte[] preGtQueuePatchData {get; set;}
 
         public MOActionAddressResolver(ISigScanner sig)
         {
-            SetUiMouseoverEntityId = sig.ScanText("48 89 91 ?? ?? ?? ?? C3 CC CC CC CC CC CC CC CC 48 89 5C 24 ?? 55 56 57 48 81 EC ?? ?? ?? ?? 48 8B 05 ?? ?? ?? ?? 48 33 C4 48 89 84 24 ?? ?? ?? ?? 48 8D B1 ?? ?? ?? ?? 44 89 44 24 ?? 48 8B EA 48 8B D9 48 8B CE 48 8D 15 ?? ?? ?? ?? 41 B9 ?? ?? ?? ??");
             GtQueuePatch = sig.ScanModule("75 49 44 8B C3 41 8B D6");
         }
 

--- a/MOAction/MOActionPlugin.cs
+++ b/MOAction/MOActionPlugin.cs
@@ -141,7 +141,7 @@ namespace MOAction
             TargetTypes = new List<TargetType>
             {
                 new EntityTarget(moAction.GetGuiMoPtr, "UI Mouseover"),
-                new EntityTarget(moAction.NewFieldMo, "Field Mouseover"),
+                new EntityTarget(moAction.getFieldMo, "Field Mouseover"),
                 new EntityTarget(() => moAction.GetActorFromPlaceholder("<t>"), "Target"),
                 new EntityTarget(() => moAction.GetActorFromPlaceholder("<f>"), "Focus Target"),
                 new EntityTarget(() => moAction.GetActorFromPlaceholder("<tt>"), "Target of Target"),

--- a/MOAction/MOActionPlugin.cs
+++ b/MOAction/MOActionPlugin.cs
@@ -129,7 +129,8 @@ namespace MOAction
                                     keystate, 
                                     gamegui,
                                     hookprovider, 
-                                    pluginLog);
+                                    pluginLog,
+                                    Jobs.ToDictionary(item => item.RowId));
 
             foreach (var jobname in JobAbbreviations)
             {

--- a/MOAction/MOActionPlugin.cs
+++ b/MOAction/MOActionPlugin.cs
@@ -30,7 +30,7 @@ namespace MOAction
 
         public MOActionConfiguration Configuration;
 
-        private DalamudPluginInterface pluginInterface;
+        private IDalamudPluginInterface pluginInterface;
         private MOAction moAction;
 
         private List<Lumina.Excel.GeneratedSheets.Action> applicableActions;
@@ -61,7 +61,7 @@ namespace MOAction
         private ICommandManager commandManager;
         private ISigScanner SigScanner;
 
-        unsafe public MOActionPlugin(DalamudPluginInterface pluginInterface,
+        unsafe public MOActionPlugin(IDalamudPluginInterface pluginInterface,
                                     ICommandManager commands,
                                     IDataManager datamanager,
                                     IGameGui gamegui,

--- a/MOAction/Target/EntityTarget.cs
+++ b/MOAction/Target/EntityTarget.cs
@@ -12,9 +12,9 @@ namespace MOAction.Target
     {
         public EntityTarget(PtrFunc func, string name) : base(func, name) { }
         public EntityTarget(PtrFunc func, string name, bool objneed) : base(func, name, objneed) { }
-        public override GameObject GetTarget()
+        public override IGameObject GetTarget()
         {
-            GameObject obj = getPtr();
+            IGameObject obj = getPtr();
             if (IsTargetValid())
                 return obj;
                 //return (uint)Marshal.ReadInt32(ptr + 0x74);
@@ -23,7 +23,7 @@ namespace MOAction.Target
 
         public override bool IsTargetValid()
         {
-            GameObject obj = getPtr();
+            IGameObject obj = getPtr();
             return obj != null;
             //return (ptr != IntPtr.Zero || (int)ptr != 0);
         }

--- a/MOAction/Target/TargetType.cs
+++ b/MOAction/Target/TargetType.cs
@@ -9,7 +9,7 @@ namespace MOAction.Target
 {
     public abstract class TargetType
     {
-        public delegate GameObject PtrFunc();
+        public delegate IGameObject PtrFunc();
         public PtrFunc getPtr;
         public string TargetName;
         public bool ObjectNeeded;
@@ -28,7 +28,7 @@ namespace MOAction.Target
             ObjectNeeded = objneed;
         }
 
-        public abstract GameObject GetTarget();
+        public abstract IGameObject GetTarget();
         public abstract bool IsTargetValid();
 
         public override string ToString() => TargetName;

--- a/MOAction/packages.lock.json
+++ b/MOAction/packages.lock.json
@@ -1,7 +1,7 @@
 {
   "version": 1,
   "dependencies": {
-    "net7.0-windows7.0": {
+    "net8.0-windows7.0": {
       "DalamudPackager": {
         "type": "Direct",
         "requested": "[2.1.12, )",

--- a/MOAction/packages.lock.json
+++ b/MOAction/packages.lock.json
@@ -4,9 +4,9 @@
     "net8.0-windows7.0": {
       "DalamudPackager": {
         "type": "Direct",
-        "requested": "[2.1.12, )",
-        "resolved": "2.1.12",
-        "contentHash": "Sc0PVxvgg4NQjcI8n10/VfUQBAS4O+Fw2pZrAqBdRMbthYGeogzu5+xmIGCGmsEZ/ukMOBuAqiNiB5qA3MRalg=="
+        "requested": "[2.1.13, )",
+        "resolved": "2.1.13",
+        "contentHash": "rMN1omGe8536f4xLMvx9NwfvpAc9YFFfeXJ1t4P4PE6Gu8WCIoFliR1sh07hM+bfODmesk/dvMbji7vNI+B/pQ=="
       }
     }
   }


### PR DESCRIPTION
Hello again, and Welcome to Dawntrail!

with Dalamud in a state where plugin developers could start fixing their plugins, I've made 99% of MoActionPlugin work, 


- re-write the CanUseAction method using the Dalamud exposed ActionManager to simplify business logic, removing the need for some specific Sigs, only leaving ground target queue patch
- Fixed the **long-standing quest instance bug**
- introduced feature: Level sync Actions, skipping over stacks if your player's level is not high enough _a stack of target cure 2, target cure 1 will skip over cure 2 in level synced satasha_
- Fixed a bug with role actions and shared actions (like scholar/summoner res) bleeding between jobs an action stack on "Swiftcast" setup on white mage and Astrologian would conflict.
- Moved the UI mouse over logic to instead rely on STRUCTS, making the only self-maintained sig the ground target queueing patch.
- Applied the changes required for API 10

**TODO**
- I've not yet taken the time and effort to find the SIG for the Ground Target Queue patch, so as the repository looks right now I've added a sneaky boolean that makes us not even attempt to do a ground target queue patch, turn that boolean to "true" & updating the SIG in the Adress Resolver and the update will be complete!

With lovely regards!
